### PR TITLE
update docs for Plug api change

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ plug IdempotencyPlug,
 
 def handle_error(conn, error) do
   conn
-  |> put_status(Plug.Exception.Handler.status(error))
+  |> put_status(Plug.Exception.status(error))
   |> json(%{error: error.message})
   |> halt()
 end


### PR DESCRIPTION
I added this package to a project of mine and noticed a small change for the docs.

Replace `Plug.Exception.Handler.status/1` with `Plug.Exception.status/1`